### PR TITLE
Update documentation regarding color alpha values

### DIFF
--- a/en/mapscript/mapscript.txt
+++ b/en/mapscript/mapscript.txt
@@ -828,18 +828,14 @@ associations.
 colorObj Attributes
 -------------------
 
+alpha : int
+    Alpha (opacity) component of color in range [0-255]
+
 blue : int
     Blue component of color in range [0-255]
 
 green : int
     Green component of color in range [0-255]
-
-pen : int
-    Don't mess with this unless you know what you are doing! 
-    
-    .. note:: Because of the issue with *pen*, setting colors by
-       individual components is unreliable.  Best practice is to use
-       setRGB(), setHex(), or assign to a new instance of colorObj().
 
 red : int
     Red component of color in range [0-255]
@@ -847,20 +843,24 @@ red : int
 colorObj Methods
 ----------------
 
-new colorObj( [ int red=0, int green=0, int blue=0, int pens=-4 ] ) : colorObj_ 
+new colorObj( [ int red=0, int green=0, int blue=0, int alpha=255 ] ) : colorObj_ 
     Create a new instance.  The color arguments are optional.
     
 setHex( string hexcolor ) : int 
     Set the color to values specified in case-independent hexadecimal
-    notation.  Calling setHex('#ffffff') assigns values of 255 to each
-    color component.  Returns MS_SUCCESS or MS_FAILURE.
+    notation.  hex must start with a '#' followed by three or four hex bytes,
+    e.g. '#ffffff' or '#ffffffff'.  If only three hex bytes are supplied, the
+	alpha will be set to 255.  Calling setHex('#ffffff') therefore assigns
+	values of 255 to each color component, including the alpha.  Returns
+	MS_SUCCESS or MS_FAILURE.
     
-setRGB( int red, int green, int blue ) : int 
-    Set all three RGB components.  Returns MS_SUCCESS or MS_FAILURE.
+setRGB( int red, int green, int blue, int alpha=255 ) : int 
+    Set all four RGBA components.  Returns MS_SUCCESS or MS_FAILURE.
     
 toHex() : string 
     Complement to setHex, returning a hexadecimal representation of the
-    color components.
+    color components.  If alpha is 255 then this is three hex bytes "#rrggbb",
+	otherwise four hex bytes "#rrggbbaa".
 
 
 .. index::

--- a/en/mapscript/php/phpmapscript.txt
+++ b/en/mapscript/php/phpmapscript.txt
@@ -387,13 +387,23 @@ Type                Name
 int             red
 int             green
 int             blue
+int             alpha
 =============== ================================================================
 
 Methods
 ...............................................................................
 
-void setRGB(int red, int green, int blue)
-    Set red, green, blue values.
+int setRGB(int red, int green, int blue, int alpha = 255)
+    Set red, green, blue and alpha values. Returns MS_SUCCESS.
+
+string toHex()
+    Get the color as a hex string "#rrggbb" or (if alpha is not 255)
+    "#rrggbbaa".
+
+int setHex(string hex)
+    Set red, green, blue and alpha values. The hex string should have the form
+    "#rrggbb" (alpha will be set to 255) or "#rrggbbaa". Returns MS_SUCCESS.
+
     
 .. index::
    triple: MapScript; PHP; errorObj


### PR DESCRIPTION
This PR updates the documentation for colorObj in SWIG- and PHP-
Mapscripts to reflect the alpha component, including the
extended methods and changed signatures introduced in
PR mapserver/mapserver#5078