### PR TITLE
Clarify label OUTLINEWIDTH w.r.t. mapserver/mapserver#4942

### DIFF
--- a/en/mapfile/label.txt
+++ b/en/mapfile/label.txt
@@ -313,9 +313,13 @@ OUTLINECOLOR [r] [g] [b] | [attribute]
    pair: LABEL; OUTLINEWIDTH
 
 OUTLINEWIDTH [integer]
-    Width of the outline if OUTLINECOLOR_ has been set. Defaults to 1. 
+    Width of the outline if OUTLINECOLOR_ has been set. Defaults to 1.
     Currently only the AGG renderer supports values greater than 1, and
-    renders these as a 'halo' effect: recommended values are 3 or 5.
+    renders these as a 'halo' effect: recommended values are 3 or 5. If the
+    renderer supports it and the text size is variable, the outline will be
+    scaled proportionally to the text and the value specified as
+    OUTLINEWIDTH_ is therefore the width at the same scale at which the
+    SIZE_ is specified.
 
 .. index::
    pair: LABEL; PARTIALS


### PR DESCRIPTION
Update for the docs to clarify the behaviour now that the scaling issue is fixed (thanks @tbonfort !)