### PR TITLE
add example with OGC WMS requests

### DIFF
--- a/en/cgi/mapserv.txt
+++ b/en/cgi/mapserv.txt
@@ -23,3 +23,10 @@ To save the output into an image file, use the pipe command such as:
 
   mapserv -nh "QUERY_STRING=map=/ms4w/apps/gmap/htdocs/gmap75.map&mode=map" > test.png
 
+To save the output of an OGC WMS GetMap request into an valid image file, 
+remove first three lines using the pipe- and e.g. tail commmands, such as:
+
+::
+
+  mapserv -nh "QUERY_STRING=EXCEPTIONS=application/vnd.ogc.se_inimage&REQUEST=GetMap&SERVICE=WMS&VERSION=1.1.1&map=/wms_server.map&SRS=EPSG:4326&BBOX=-180,-90,180,90&FORMAT=image/png&WIDTH=1200&HEIGHT=900&LAYERS=satellite_mod" | tail -n +3 > test.png
+


### PR DESCRIPTION
I was naively using mapserv cgi to test WMS requests.

Only, after I lost quiet some time and with help of people from mailing list: <http://lists.osgeo.org/pipermail/mapserver-users/2015-May/077860.html>  it turned out that WMS output prepends 3 extra lines indicating the mime-type (is this a bug or a feature?). 

This pull request indicates one way to deal with this. Hope it helps also others.