### PR TITLE
Fixed syntax for min/max-zoom of composite cache

### DIFF
--- a/en/mapcache/caches.txt
+++ b/en/mapcache/caches.txt
@@ -817,8 +817,8 @@ higher zoom-level to a temporary (i.e. memcache) cache.
    <cache name="mymemcache" ...> ... </cache>
    <cache name="composite" type="composite">
       <cache grids="mygrid,g">mycache</cache>
-      <cache minzoom="0" maxzoom="8">mydisk</cache>
-      <cache minzoom="9">mymemcache</cache>
+      <cache min-zoom="0" max-zoom="8">mydisk</cache>
+      <cache min-zoom="9">mymemcache</cache>
    </cache>
    <tileset ...>
       <cache>composite</cache>
@@ -834,8 +834,8 @@ succession of min/max zoom values and grids makes sense, e.g.:
 .. code-block:: xml
 
    <cache name="composite" type="composite">
-      <cache minzoom="0">cache1</cache>
-      <cache minzoom="9">this_cache_will_never_be_used</cache>
+      <cache min-zoom="0">cache1</cache>
+      <cache min-zoom="9">this_cache_will_never_be_used</cache>
    </cache>
 
 


### PR DESCRIPTION
The syntax for min/max-zoom uses a dash, fixed the documentation in this PR.