### PR TITLE
Some light copy editing in MapCache cache-types doc

### DIFF
--- a/en/mapcache/caches.txt
+++ b/en/mapcache/caches.txt
@@ -7,7 +7,7 @@ Cache Types
 :Author: Thomas Bonfort
 :Contact: tbonfort at terriscope.fr
 
-This document details the different cache backends that can be used to store tiles
+This document details the different cache backends that can be used to store tiles.
 
 .. _mapcache_cache_disk:
 
@@ -17,7 +17,7 @@ Disk Caches
 The disk based cache is the simplest cache to configure, and the one with the
 the fastest access to existing tiles. It is ideal for small tile repositories,
 but will often cause trouble for sites hosting millions of tiles, as the number of 
-files or directory may rapidly overcome the capabilities of the underlying
+files or directories may rapidly overcome the capabilities of the underlying
 filesystem. Additionaly, the block size chosen for the filesystem must closely
 match the mean size of a stored tile: ideally, any given tile should just fit
 inside a filesystem block, so as not to waste storage space inside each block,
@@ -45,8 +45,8 @@ create a symbolic link to a single uniform color tile instead of storing the
 actual blank data in the tile's file.
 
 All caches support the <creation_retry> option, which specifies the number of
-times mapcache should retry if it failed to create a tile's file or symlink. The
-default is to fail immediately, you may want to set this to a positive value 
+times MapCache should retry if it failed to create a tile's file or symlink. The
+default is to fail immediately: You may want to set this to a positive value 
 if using a network mounted filesystem where transient errors are common.
 
 Default Structure
@@ -68,8 +68,8 @@ a symbolic link to a single blank tile to gain disk space.
       <symlink_blank/>
    </cache>
 
-The two only configuration keys are the root directory where the tiles will be
-stored, and a key to activate the symbolic linking of blank tiles
+The only two configuration keys are the root directory where the tiles will be
+stored, and a key to activate the symbolic linking of blank tiles.
 
 
 Arcgis Compatible Structure
@@ -97,7 +97,7 @@ Worldwind Compatible Structure
    </cache>
 
 This layout creates a tile structure compatible with a worldwind cache. Tiles
-will be stored in files that ressemble `/tmp/{tileset}/{grid}/{dimension}/{z}/{y}/{y}_{x}.ext`
+will be stored in files that resemble `/tmp/{tileset}/{grid}/{dimension}/{z}/{y}/{y}_{x}.ext`
 
 
 Template Structure
@@ -138,10 +138,10 @@ value for each tile to store.
 
 .. _mapcache_cache_bdb:
 
-BerkeleyDB Caches
+Berkeley DB Caches
 --------------------------------------------------------------------------------
 
-The BerkeleyDB cache backend stores tiles in a key-value flat-file database.
+The Berkeley DB cache backend stores tiles in a key-value flat-file database,
 and therefore does not have the disadvantages of disk caches with regards to
 the number of files stored on the filesystem. As the image blobs are stored
 contiguously, the block size chosen for the filesystem has no influence on the
@@ -149,11 +149,11 @@ storage capacity of the volume.
 
 Note that for a given bdb cache, only a single database file is created, which
 will store the tiles of its associated tilesets (i.e. there is not a database
-file created per tileset, grid, and or dimension). If you need to store different
+file created per tileset, grid, and/or dimension). If you need to store different
 tilesets to different files, then use multiple dbd cache entries. It is not
 possible to use multiple database files for tileset grids or dimensions.
 
-The berkeleyDB based caches are a bit faster than the disk based caches during
+The Berkeley DB based caches are a bit faster than the disk based caches during
 reads, but may be a bit slower during concurrent writes if a high number of
 threads all try to insert new tiles concurrently.
 
@@ -161,7 +161,7 @@ threads all try to insert new tiles concurrently.
 
    <cache name="bdb" type="bdb">
       <!-- base (required)
-         absolute filesystem path where the berkeley db database file is to be stored.
+         absolute filesystem path where the Berkeley DB database file is to be stored.
          this directory must exist, and be writable
       -->
       <base>/tmp/foo/</base>
@@ -177,17 +177,17 @@ threads all try to insert new tiles concurrently.
 
 .. _mapcache_cache_sqlite:
 
-Sqlite Caches
+SQLite Caches
 --------------------------------------------------------------------------------
 
-There are two different sqlite caches that vary by the database schema they
-create and query. Sqlite caches have the advantage that they store tiles as
+There are two different SQLite caches that vary by the database schema they
+create and query. SQLite caches have the advantage that they store tiles as
 blobs inside a single database file, and therefore do not have the
 disadvantages of disk caches with regards to the number of files stored. As the
 image blobs are stored contiguously, the block size chosen for the filesystem
-has no influence on the storage capacity of he volume.
+has no influence on the storage capacity of the volume.
 
-The sqlite based caches are a bit slower than the disk based caches, and may
+The SQLite based caches are a bit slower than the disk based caches, and may
 have write-locking issues at seed time if a high number of threads all try to
 insert new tiles concurrently.
 
@@ -195,7 +195,7 @@ insert new tiles concurrently.
 Default Schema
 ================================================================================
 
-Tiles are stored in the configured sqlite file created by mapcache with
+Tiles are stored in the configured SQLite file created by MapCache with
 
 .. code-block:: sql
 
@@ -218,8 +218,8 @@ Tiles are stored in the configured sqlite file created by mapcache with
    </cache>
 
 
-You may also add custom sqlite pragmas that will be executed when first 
-connecting to a sqlite db, e.g. to override some compiled in sqlite
+You may also add custom SQLite pragmas that will be executed when first 
+connecting to a SQLite db, e.g. to override some compiled-in SQLite
 defaults
 
 .. code-block:: xml
@@ -239,10 +239,10 @@ defaults
 Custom Schema
 ================================================================================
 
-This cache can use any database schema, it is up to you to supply the SQL that
+This cache can use any database schema: It is up to you to supply the SQL that
 will be exectuted to select or insert a new tile.
 
-In order to use such a functionality you should supply the sql queries that will
+In order to use such functionality you should supply the SQL queries that will
 be used against your custom schema. It is up to you to make sure your queries are 
 correct and will return the correct data for a given tileset, dimension, grid, x,
 y and z.
@@ -268,10 +268,10 @@ creation timestamp for that tile.
 Blank Tile Detection
 ====================
 
-Mapcache's sqlite caches support the detection and storage of blank (i.e. uniform
+MapCache's SQLite caches support the detection and storage of blank (i.e. uniform
 color) tiles, and will store a quadruplet of the rgba color component in the data
 blob instead of the compressed image data itself. That quadruplet will be
-transformed on-the-fly to a 1-bit paletted png before being returned to the client.
+transformed on-the-fly to a 1-bit palleted PNG before being returned to the client.
 
 
 .. code-block:: xml
@@ -283,15 +283,15 @@ transformed on-the-fly to a 1-bit paletted png before being returned to the clie
 
 .. note::
    
-   sqlite files created with this option will only be fully understood by
-   mapcache as each tile blob may contain a #rgba quadruplet instead of
-   the expected png or jpeg data.
+   SQLite files created with this option will only be fully understood by
+   MapCache as each tile blob may contain a #rgba quadruplet instead of
+   the expected PNG or JPEG data.
 
 
-Using multiple sqlite database files
+Using multiple SQLite database files
 ====================================
 
-You may want to split an sqlite cache into multiple files, for organisational
+You may want to split an SQLite cache into multiple files, for organisational
 purposes, or to keep the size of each file to a reasonable limit if caching
 large amounts of data.
 
@@ -325,26 +325,26 @@ The following template keys are available for operating on the given tile's
 x,y, and z:
 
 - `{z}` is replaced by the zoom level
-- `{x}` is replaced by the x value of the leftmost tile inside the sqlite file
+- `{x}` is replaced by the x value of the leftmost tile inside the SQLite file
   containing the requested tile
 - `{inv_x}` is replaced by the x value of the rightmost tile.
 - `{y}` is replaced by the y value of the bottommost tile.
 - `{inv_y}` is replaced by the y value of the topmost tile.
-- `{div_x}` is replaced by the index of the sqlite file starting from the left
+- `{div_x}` is replaced by the index of the SQLite file starting from the left
   of the grid (i.e. `{div_x} = {x}/<xcount>`)
 - `{inv_div_x}` same as {div_x} but starting from the right.
-- `{div_y}` is replaced by the index of the sqlite file starting from the bottom
+- `{div_y}` is replaced by the index of the SQLite file starting from the bottom
   of the grid (i.e. `{div_y} = {y}/<ycount>`)
 - `{inv_div_y}` same as `{div_y}` but starting from the top.
 
 .. note::
 
    {inv_x} and {inv_div_x} will probably be rarely used, whereas
-   {inv_y} and {inv_div_y} will find some usage for people who prefer to index
+   {inv_y} and {inv_div_y} will find some usage by people who prefer to index
    their dbfiles files from top to bottom rather than bottom to top.
 
-In some occurences, it may be desirable to have a precise hand on the
-filename to use for a given x,y,z, tile lookup, e.g. to look for a file
+In some occurrences, it may be desirable to have a precise hand on the
+filename to use for a given x,y,z tile lookup, e.g. to look for a file
 named `Z03-R00003-C000009.sqlite3` instead of just `Z3-R3-C9.sqlite3`. The 
 <dbfile> entry supports formatting attributes, following the unix
 printf syntax ( c.f.: http://linux.die.net/man/3/printf ), by suffixing
@@ -369,11 +369,11 @@ each template key with "_fmt", e.g.:
 MBTiles caches
 --------------
 
-This cache type is a shortcut to the previous custom schema sqlite cache, with
+This cache type is a shortcut to the previous custom schema SQLite cache, with
 pre-populated SQL queries that correspond to the MBTiles specification.
 
-Although the default mbtiles schema is very simple, mapcache uses the same multi-
-table schema found in most downloadable mbtiles file, to notably enable storing
+Although the default mbtiles schema is very simple, MapCache uses the same multi-
+table schema found in most downloadable mbtiles files, notably to enable storing
 blank (i.e. uniform) tiles without duplicating the encoded image data (in the 
 same way the disk cache supports tile symlinking).
 
@@ -413,7 +413,7 @@ The mbtiles schema is created with:
 
 .. note::
    
-   Contrarily to the standard sqlite mapcache schema, the mbtiles db file only
+   Contrarily to the standard SQLite MapCache schema, the mbtiles db file only
    supports a single tileset per cache. The behavior if multiple tilesets are
    associated to the same mbtiles cache is undefined, and will definitely
    produce incorrect results.
@@ -421,23 +421,23 @@ The mbtiles schema is created with:
 
 .. warning:: 
 
-   When working with multiple processes (-p switch) and sqlite cache 
+   When working with multiple processes (-p switch) and SQLite cache 
    backends, some errors may appear under high concurrency when writing to the 
-   sqlite database (error: SQL logic error or missing database (1)). 
-   Upgrading to sqlite >= 3.7.15 seems to resolve this issue.
+   SQLite database (error: SQL logic error or missing database (1)). 
+   Upgrading to SQLite >= 3.7.15 seems to resolve this issue.
 
 .. _mapcache_cache_memcache:
 
 Memcache Caches
 --------------------------------------------------------------------------------
 
-This cache type stores tile to an external memcached server running on the local
+This cache type stores tiles to an external memcached server running on the local
 machine or accessible on the network. This cache type has the advantage that 
 memcached takes care of expiring tiles, so the size of the cache will never
 exceed what has been configured in the memcache instance.
 
 Memcache support requires a rather recent version of the apr-util library. Note
-that under very high loads (usually only atainable on synthetic benchmarks on
+that under very high loads (usually only attainable on synthetic benchmarks on
 localhost), the memcache implementation of apr-util may fail and start dropping
 connections for some intervals of time before coming back online afterwards.
 
@@ -455,13 +455,13 @@ You can add multiple <server> entries.
 
 .. note::
    Tiles stored in memcache backends are configured to expire in 1 day by
-   default. This can be overriden at the tileset level with the <auto_expire>
+   default. This can be overridden at the tileset level with the <auto_expire>
    keyword.
 
 To limit the memory used by blank tiles inside the memcache instance, you
 may enable blank tile detection, in which case a `#rgba` quadruplet will
 be stored to the cache instead of the actual image data. MapCache will convert
-that on the fly to a 1-bit paletted PNG image before returning it to the client.
+that on-the-fly to a 1-bit palleted PNG image before returning it to the client.
 
 
 .. code-block:: xml
@@ -480,7 +480,7 @@ TIFF caches are the most recent addition to the family of caches, and use the
 internal tile structure of the TIFF specification to access tile data. Tiles can
 be stored in JPEG only (TIFF does not support PNG tiles).
 
-As a single tiff file may contain many tiles, there is a drastic reduction in
+As a single TIFF file may contain many tiles, there is a drastic reduction in
 the number of files that have to be stored on the filesystem, which solves the
 major shortcomings of the disk cache. Another advantage is that the same TIFF
 files can be used by programs or WMS servers that only understand regular GIS
@@ -488,20 +488,20 @@ raster formats, and be served up with high performance for tile access.
 
 The TIFF cache should be considered read-only for the time being. Write access
 is already possible but should be considered experimental as there might be
-some file corruption issues, notably on network file-systems. Note that until
-all the tiles in a given tiff file have been seeded/created, the TIFF file is
-said to be "sparse" in the sense that it is missing a number of jpeg tiles. As
-such most non-gdal based programs will have problems opening these incomplete
+some file corruption issues, notably on network filesystems. Note that until
+all the tiles in a given TIFF file have been seeded/created, the TIFF file is
+said to be "sparse" in the sense that it is missing a number of JPEG tiles. As
+such, most non-GDAL based programs will have problems opening these incomplete
 files.
 
-Note that the tiff tile structure must
-exactly match the structure of the grid used by the tileset, and the tif file
+Note that the TIFF tile structure must
+exactly match the structure of the grid used by the tileset, and the TIFF file
 names must follow strict naming rules.
 
 Defining the TIFF file sizes
 ===============================
 
-The number of tiles stored in each the horizontal and vertical direction
+The number of tiles stored in each of the horizontal and vertical directions
 must be defined:
 
 - <xcount> the number of tiles stored along the x (horizontal) direction of
@@ -548,14 +548,14 @@ x,y, and z:
 .. note::
 
    {inv_x} and {inv_div_x} will probably be rarely used, whereas
-   {inv_y} and {inv_div_y} will find some usage for people who prefer to index
+   {inv_y} and {inv_div_y} will find some usage by people who prefer to index
    their TIFF files from top to bottom rather than bottom to top.
 
 Customizing the template keys
 ======================================
 
-In some occurences, it may be desirable to have a precise hand on the
-filename to use for a given x,y,z, tile lookup, e.g. to look for a file
+In some occurrences, it may be desirable to have a precise hand on the
+filename to use for a given x,y,z tile lookup, e.g. to look for a file
 named "Z03-R00003-C000009.tif" instead of just "Z3-R3-C9.tif". The 
 <template> entry supports formatting attributes, following the unix
 printf syntax ( c.f.: http://linux.die.net/man/3/printf ), by suffixing
@@ -580,7 +580,7 @@ Setting JPEG compression options
 An additional optional parameter defines which JPEG compression should be 
 applied to the tiles when saved into the TIFF file:
 
-- <format> the name of the (jpeg) format to use
+- <format> the name of the (JPEG) format to use
 
 .. seealso:: :ref:`mapcache_jpeg_format`
 
@@ -592,17 +592,17 @@ applied to the tiles when saved into the TIFF file:
    </cache>
 
 In this example, assuming a grid using 256x256 tiles, the files that are read
-to load the tiles are tiled TIFFs with jpeg compression, who's size are
+to load the tiles are tiled TIFFs with JPEG compression, whose size are
 16384x16384. The number of files to store on disk is thus reduced 4096 times
 compared to the basic disk cache.
 
 Using a specific locker
 =======================
 
-Mapcache needs to create a :ref:`lock <mapcache_locks>` when writing inside a
+MapCache needs to create a :ref:`lock <mapcache_locks>` when writing inside a
 TIFF file to ensure that no two instances are updating the same file
-concurrently. By default the global mapcache locker will be used, you can
-however configure a different locking mechanism or behavior by configuring it
+concurrently. By default the global MapCache locker will be used; you can,
+however, configure a different locking mechanism or behavior by configuring it
 inside the TIFF cache itself.
 
 .. seealso:: :ref:`mapcache_locks`
@@ -617,14 +617,14 @@ inside the TIFF cache itself.
 GeoTIFF Support
 ===========================
 
-If compiled with GeoTiff and write support, MapCache will add referencing
+If compiled with GeoTIFF and write support, MapCache will add referencing
 information to the TIFF files it creates, so that the TIFF files can be used
-in any geotiff- enabled software. Write support does not produce full geotiffs
+in any GeoTIFF-enabled software. Write support does not produce full GeoTIFFs
 with the definition of the projection used, but only the pixel scale and
-tie-points, i.e.  what is usually found in .tfw files.
+tie-points, i.e. what is usually found in .tfw files.
 
 For reference, here is the gdalinfo output on a TIFF file created by MapCache
-when compiled with geotiff support:
+when compiled with GeoTIFF support:
 
 ::
 
@@ -659,7 +659,7 @@ providers.
 Pure REST Cache
 ===============
 
-This cache type can be used to store tiles to a webdav enabled server. You
+This cache type can be used to store tiles to a WebDAV enabled server. You
 must provide a template URL that should be used when accessing a tile with
 a given x,y,z, etc...
 
@@ -733,8 +733,8 @@ to add the layer of authentication/authorization needed for that platform.
    </cache>
 
 The <id> <secret> and <region> tags are required and are obtained and configured
-through your amazon management console. You should read the documentation as to
-what headers you want to be adding to your requests depending on your usecase (the
+through your Amazon management console. You should read the documentation as to
+what headers you want to be adding to your requests depending on your use case (the
 supplied example hosts tiles on cheaper storage, and allows them to be publicly
 accessible).
 
@@ -761,7 +761,7 @@ to add the layer of authentication/authorization needed for that platform.
 
 The <id> <secret> and <container> tags are required and are obtained and configured
 through your management console. You should read the documentation as to
-what headers you want to be adding to your requests depending on your usecase.
+what headers you want to be adding to your requests depending on your use case.
 
 
 .. _mapcache_cache_rest_google:
@@ -769,7 +769,7 @@ what headers you want to be adding to your requests depending on your usecase.
 Google Cloud Storage REST Caches
 ================================
 
-The REST cache has been specialized to enable access to Google cloud storage, in order
+The REST cache has been specialized to enable access to Google Cloud Storage, in order
 to add the layer of authentication/authorization needed for that platform.
 
 .. code-block:: xml
@@ -787,17 +787,17 @@ to add the layer of authentication/authorization needed for that platform.
 
 The <access> and <secret> tags are required and are obtained and configured
 through your management console. You should read the documentation as to
-what headers you want to be adding to your requests depending on your usecase.
-Note that support for Google cloud storage uses its Amazon compatibility layer.
+what headers you want to be adding to your requests depending on your use case.
+Note that support for Google Cloud Storage uses its Amazon compatibility layer.
 
 .. _mapcache_cache_meta:
 
 Meta Caches
 ----------------
 
-These cache types do not store tiles themselves, however they delegate the
+These cache types do not store tiles themselves, but rather delegate the
 storage of a tile to a number of child caches based on a set of rules or
-behaviors. These caches are mostly usefull for large mapcache deployments
+behaviors. These caches are mostly useful for large MapCache deployments
 across multiple instances, with shared cache backends (i.e. dedicated memcache
 servers, and network mounted filer filesystems).
 
@@ -809,7 +809,7 @@ Composite Caches
 
 This cache uses different child caches depending on the tile's zoom level, and
 can be used for example to store low zoom-level tiles to permanent storage, and
-higher zoom-level to a temporary (i.e. memcache) cache.
+higher zoom-level tiles to a temporary (i.e. memcache) cache.
 
 .. code-block:: xml
 
@@ -846,7 +846,7 @@ Fallback Caches
 
 These cache types will return tiles from the first configured subcache that does
 not return an error. They can be used when one of the caches is prone to error
-conditions (e.g. remote rest caches, memcache)
+conditions (e.g. remote REST caches, memcache)
 
 
 .. code-block:: xml
@@ -904,7 +904,7 @@ performance depending on storage costs, time to recreate missing tiles, etc...
    </tileset>
 
 In the previous example, all tiles are primarily accessed from a memcache instance, however
-the lower zoom level tiles are backed up to a permanent sqlite cache which will be used to
+the lower zoom level tiles are backed up to a permanent SQLite cache which will be used to
 populate the fast memcache cache e.g. on restarts.
 
 .. _mapcache_cache_riak:


### PR DESCRIPTION
Spelling corrections, some punctuation corrections/improvements, changes for
internal consistency, capitalization of proper (e.g. company or software)
names, etc.