### PR TITLE
Standardise Mapfile keyword and parameter docs

### DIFF
--- a/en/mapfile/class.txt
+++ b/en/mapfile/class.txt
@@ -10,7 +10,7 @@
 .. index::
    pair: CLASS; BACKGROUNDCOLOR
     
-BACKGROUNDCOLOR [r] [g] [b] | [hexadecimal string] - `deprecated`
+BACKGROUNDCOLOR [r] [g] [b] | [hexadecimal string]
 
     .. deprecated:: 6.0 Use `CLASS` :ref:`style`\s.
  

--- a/en/mapfile/cluster.txt
+++ b/en/mapfile/cluster.txt
@@ -25,7 +25,7 @@ This feature was added through :ref:`rfc69`.
 Supported Layer Types
 =====================
 
-POINT
+Only layers of ``TYPE POINT`` are supported. 
 
 Mapfile Parameters
 ==================

--- a/en/mapfile/composite.txt
+++ b/en/mapfile/composite.txt
@@ -8,7 +8,7 @@
 *****************************************************************************
 
 Background
-------------------------------------
+==========
 
 The `COMPOSITE` block is used to achieve blending effects with
 MapServer.
@@ -27,7 +27,7 @@ Performance is affected by advanced blending (all modes except
 `src-over`).
 
 Parameters
-------------------------------------
+==========
 
 .. index::
    pair: COMPOSITE; OPACITY
@@ -35,13 +35,14 @@ Parameters
 .. _opacity:
 
 OPACITY [integer]
-
     Sets the opacity level (or the inability to see through the layer) of all
     classed pixels for a given layer.  A value of 100 is opaque and 
     0 is fully transparent.
 
+.. index::
+	pair: COMPOSITE; COMPOP
+   
 COMPOP [string]
-
     Name of the compositing operator to use when blending the temporary image
     onto the main map image. See `http://en.wikipedia.org/wiki/Blend_modes`.
     The default compositing operator is "src-over".
@@ -82,7 +83,7 @@ COMPOP [string]
     "src-over" when this is not the case.
 
 Usage
-------------------------------------
+=====
 
 Simple transparency / opacity is achieved by only specifying the
 `OPACITY` parameter (this achieves the same effect as the legacy

--- a/en/mapfile/layer.txt
+++ b/en/mapfile/layer.txt
@@ -647,7 +647,6 @@ METADATA
     pair: LAYER; MINGEOWIDTH
 
 MINGEOWIDTH [double]
-
     Minimum width, in the map's geographic units, at which this LAYER
     is drawn.  If MINSCALEDENOM is also specified then MINSCALEDENOM
     will be used instead.

--- a/en/mapfile/layer.txt
+++ b/en/mapfile/layer.txt
@@ -1399,7 +1399,7 @@ TRANSPARENCY [integer|alpha] - deprecated
 .. index::
    pair: LAYER; TRANSFORM
 
-TRANSFORM [true|false ul|uc|ur|cl|cc|cr|ll|lc|lr]
+TRANSFORM [true|false] | [ul|uc|ur|cl|cc|cr|ll|lc|lr]
     Tells MapServer whether or not a particular layer needs to be transformed
     from some coordinate system to image coordinates. Default is true. This
     allows you to create shapefiles in image/graphics coordinates and

--- a/en/mapfile/outputformat.txt
+++ b/en/mapfile/outputformat.txt
@@ -326,7 +326,7 @@ FORMATOPTION [option]
 .. index::
    pair: OUTPUTFORMAT; IMAGEMODE
     
-IMAGEMODE [PC256/RGB/RGBA/INT16/FLOAT32/FEATURE]
+IMAGEMODE [PC256|RGB|RGBA|INT16|FLOAT32|FEATURE]
     Selects the imaging mode in which the output is generated. Does matter 
     for non-raster formats like Flash. Not all formats support all 
     combinations. For instance GD supports only PC256. (optional)

--- a/en/mapfile/outputformat.txt
+++ b/en/mapfile/outputformat.txt
@@ -395,7 +395,7 @@ NAME [name]
 .. index::
    pair: OUTPUTFORMAT; TRANSPARENT
     
-TRANSPARENT [ON/OFF]
+TRANSPARENT [on|off]
     Indicates whether transparency should be enabled for this format. Note 
     that transparency does not work for IMAGEMODE RGB output. Not all formats 
     support transparency (optional). When transparency is enabled for the 


### PR DESCRIPTION
- Standardise use of pipe for parameter options
- Add in missing keywords

These allow easier parsing of docs to extract parameters and Mapfile keywords. 