### PR TITLE
Add in PROJ_DEBUG CONFIG setting

### DIFF
--- a/en/mapfile/map.txt
+++ b/en/mapfile/map.txt
@@ -155,6 +155,12 @@ CONFIG [key] [value]
 
              CONFIG "PROJ_LIB" "C:/somedir/proj/nad/"
 
+    .. index::
+       triple: MAP; CONFIG; PROJ_DEBUG
+
+    PROJ_DEBUG [ON|OFF]
+        Turn on PROJ debugging. See :ref:`debugging` for more details. 
+
 .. index::
    pair: MAP; DATAPATTERN
     


### PR DESCRIPTION
Docs currently mention GDAL.OGR config settings are documented elsewhere, but the PROJ ones are only mentioned in the DEBUG doc. 