### PR TITLE
Add OUTPUT format keyword

### DIFF
--- a/en/mapfile/map.txt
+++ b/en/mapfile/map.txt
@@ -369,6 +369,12 @@ NAME [name]
     using this mapfile. It should be kept short.
 
 .. index::
+   pair: MAP; OUTPUTFORMAT
+    
+:ref:`OUTPUTFORMAT`
+    Signals the start of a :ref:`OUTPUTFORMAT` object.
+
+.. index::
    pair: MAP; PROJECTION
     
 :ref:`PROJECTION`


### PR DESCRIPTION
For completeness - the OUTPUT format wasn't listed as a keyword. 