### PR TITLE
Typo and missing info for sources list

### DIFF
--- a/en/mapcache/config.txt
+++ b/en/mapcache/config.txt
@@ -29,9 +29,9 @@ Source
 ================================================================================
 
 A source is a service mod-mapcache can query to obtain image data. This is
-typically a WMS server accessible by a URL. (There are currently no sources
-other than WMS implemented, though others may be added later if the need
-arises).
+typically a WMS server accessible by a URL. (There are currently only WMS, WMTS
+and mapfile as sources, though others may be added later if the need arises,
+see :ref:`mapcache_sources`).
 
 .. code-block:: xml
 
@@ -86,17 +86,17 @@ arises).
       </http>
    </source>
 
-* The name and type attributes are straightforward: `type` is "wms", and `name`
-* is the key by which this source will be referenced; `<url>` is the HTTP
-* location where the service can be accessed; and `<wmsparams>` is a list of
-* parameters that will be added to the WMS request. You should probably at the
-* very least add the FORMAT and LAYERS parameters. By convention(?), WMS
-* parameters are uppercase, and you should respect this convention in your
-* configuration file.
-*
-* This is where you can also override some default WMS parameters if needed. By
-* default, the parameters that will be used are: `<REQUEST>GetMap</REQUEST>`
-* `<SERVICE>WMS</SERVICE>` `<STYLES></STYLES>` `<VERSION>1.1.0</VERSION>`
+The name and type attributes are straightforward: `type` is "wms", and `name`
+is the key by which this source will be referenced; `<url>` is the HTTP
+location where the service can be accessed; and `<wmsparams>` is a list of
+parameters that will be added to the WMS request. You should probably at the
+very least add the FORMAT and LAYERS parameters. By convention(?), WMS
+parameters are uppercase, and you should respect this convention in your
+configuration file.
+
+This is where you can also override some default WMS parameters if needed. By
+default, the parameters that will be used are: `<REQUEST>GetMap</REQUEST>`
+`<SERVICE>WMS</SERVICE>` `<STYLES></STYLES>` `<VERSION>1.1.0</VERSION>`
 
 Cache
 ================================================================================


### PR DESCRIPTION
* remove star at the start of the line for description of source example
* update sources list