### PR TITLE
Added warning

### DIFF
--- a/en/installation/php.txt
+++ b/en/installation/php.txt
@@ -1,3 +1,6 @@
+.. warning::
+         GD support has been removed in Mapserver 7
+
 .. _php_install:
 
 *****************************************************************************


### PR DESCRIPTION
 GD support has been removed in Mapserver 7 so i added warning in PHP installation docs.