### PR TITLE
Added warning

### DIFF
--- a/en/mapfile/outputformat.txt
+++ b/en/mapfile/outputformat.txt
@@ -1,3 +1,6 @@
+.. warning::
+         GD support has been removed in Mapserver 7
+
 .. index::
    single: OUTPUTFORMAT
     


### PR DESCRIPTION
 GD support has been removed in Mapserver 7 so i added warning output format.