### PR TITLE
Added warning

### DIFF
--- a/en/mapfile/label.txt
+++ b/en/mapfile/label.txt
@@ -1,3 +1,6 @@
+.. warning::
+         GD support has been removed in Mapserver 7
+
 .. index::
    single: LABEL
 


### PR DESCRIPTION
 GD support has been removed in Mapserver 7 so i added warning in Label