### PR TITLE
Added warning

### DIFF
--- a/en/installation/unix.txt
+++ b/en/installation/unix.txt
@@ -1,3 +1,6 @@
+.. warning::
+         GD support has been removed in Mapserver 7
+
 .. index::
    pair: Unix; Installation
 


### PR DESCRIPTION
GD support was removed in Mapserver 7 so i added a warning in unix