### PR TITLE
Wrong Spellings

### DIFF
--- a/en/glossary.txt
+++ b/en/glossary.txt
@@ -50,7 +50,7 @@
 
         .. warning::
 
-          GD support was removed in Mapserver 7.0.
+          GD support was removed in MapServer 7.0.
         
     GDAL
         GDAL (Geospatial Data Abstraction Library) is a multi-format raster


### PR DESCRIPTION
The spelling of MapServer was wrong in Glossary