### PR TITLE
Wrong Spelling

### DIFF
--- a/en/mapfile/symbol.txt
+++ b/en/mapfile/symbol.txt
@@ -68,7 +68,7 @@ ANTIALIAS [true|false]
 
     .. warning::
 
-       GD support was removed in Mapserver 7.0.
+       GD support was removed in MapServer 7.0.
 
 .. index::
    pair: SYMBOL; CHARACTER


### PR DESCRIPTION
Spelling of MapServer was wrong in SYMBOL.