### PR TITLE
Add information about !BOX! variable

### DIFF
--- a/en/mapfile/layer.txt
+++ b/en/mapfile/layer.txt
@@ -183,6 +183,14 @@ DATA [filename]|[sde parameters][postgis table/column][oracle table/column]
     submitted by forcing an error, for instance by submitting a DATA parameter
     you know won't work, using for example a bad column name.
 
+    In a standard use case, when PostGIS, SpatiaLite, or GeoPackage are used as data
+    source the BBOX filter (bounding boxes intersect, `&&` with PostGIS) is used
+    automatically. However in some rare use case, a subquery can be very time
+    consuming if data is really important as the final data will be filtered only
+    in the query. In order to filter data sooner, ie before the final query, one
+    can filter data directly in the subquery using the !BOX! variable: 
+    `WHERE ST_Intersects(wkb_geometry,!BOX!)`.
+
     .. seealso::
 
        :ref:`vector` for specific connection information for various


### PR DESCRIPTION
Fix #226

In some use case, we need to filter data before the final query in order to
avoid to get too much data in a subquery.