### PR TITLE
Update WMS Client documentation for support of 1.3.0

### DIFF
--- a/en/ogc/ogc_support.txt
+++ b/en/ogc/ogc_support.txt
@@ -7,12 +7,7 @@
 MapServer  OGC Specification support
 *******************************************************************************
 
-* Web Map Service (OGC:WMS)
-
-  * Server:  1.0.0, 1.0.7, 1.1.0, 1.1.1, 1.3.0
-
-  * Client: 1.0.0, 1.0.7, 1.1.0, 1.1.1
-
+* Web Map Service (OGC:WMS) 1.0.0, 1.0.7, 1.1.0, 1.1.1, 1.3.0
 * Web Feature Service (OGC:WFS) 1.0.0, 1.1.0, 2.0
 * Web Coverage Service (OGC:WCS) 1.0.0, 1.1.0, 2.0.0, 2.0.1
 * Geography Markup Language (OGC:GML) 2.1.2, 3.1.0 Level 0 Profile, 3.2.1

--- a/en/ogc/wms_client.txt
+++ b/en/ogc/wms_client.txt
@@ -26,7 +26,7 @@ MapServer's WMS connection type to include layers from remote WMS servers in
 MapServer applications.
 
 MapServer  supports the following WMS versions when acting as client:
-1.0.0, 1.0.7, 1.1.0, 1.1.1 (see :ref:`ogc_support` for an updated
+1.0.0, 1.0.7, 1.1.0, 1.1.1, 1.3.0 (see :ref:`ogc_support` for an updated
 list).
 
 This document assumes that you are already familiar with certain aspects of 
@@ -41,6 +41,7 @@ WMS-Related Information
 
 - :ref:`MapServer WMS Server HowTo <wms_server>`
 - `WMS 1.1.1 specification`_
+- `WMS 1.3.0 specification`_
 - `MapServer OGC Web Services Workshop package`_ 
 
 Compilation / Installation
@@ -487,6 +488,13 @@ Optional Layer Parameters and Metadata
   behaviors with reprojection in some areas.  The contents of this metadata item should be of the form
   "minx miny maxx maxy".  This feature is new to MapServer 6.0.
 
+- **"wms_strict_axis_order metadata**
+  - set this to "1" or "true" to force WMS requests to use strict axis order according to the EPSG code,
+  or "0" or "false" to force WMS requests to always use xy (or lonlat) axis order. This should only be
+  necessary if the axis order interpretation of the server for the chosen EPSG code does not conform to
+  the standard: In the case of WMS 1.0 and 1.1 the assumption is to always use xy (default 0/false),
+  for WMS 1.3.0 the assumption is strict axis order according to the EPSG database (default 1/true).
+
 .. note::
 
     Note that each of the above metadata can also be referred to as 'ows_*' instead of 'wms_*'. 
@@ -537,6 +545,7 @@ Limitations/TODO
 .. #### rST Link Section ####
 
 .. _`WMS 1.1.1 specification`: http://portal.opengeospatial.org/files/?artifact_id=1081&version=1&format=pdf
+.. _`WMS 1.3.0 specification`: http://portal.opengeospatial.org/files/?artifact_id=14416
 .. _`MapServer OGC Web Services Workshop package`: http://mapserver.github.io/ms-ogc-workshop/ 
 .. _`libcurl`: http://curl.haxx.se/libcurl/c/
 .. _`MS4W`: http://www.ms4w.com


### PR DESCRIPTION
Companion PR to update documentation to reflect support for WMS 1.3.0 as client in mapserver/mapserver#5547

Should not be merged until/unless mapserver/mapserver#5547 is also accepted (and then to the appropriate branch - either master and/or 7.0 as for mapserver/mapserver#5547)