### PR TITLE
Add in missing COLORRANGE, DATARANGE, RANGEITEM keywords to STYLE. 

### DIFF
--- a/en/mapfile/style.txt
+++ b/en/mapfile/style.txt
@@ -159,6 +159,32 @@ COLOR [r] [g] [b] | [hexadecimal string] | [attribute]
       The associated RFC document for this feature is :ref:`RFC19`.
 
 .. index::
+   pair: STYLE; COLORRANGE
+
+COLORRANGE [r] [g] [b] [r] [g] [b] | [hexadecimal string] [hexadecimal string]
+    Defines two colors to correspond to the low
+    and high ends of the ``DATARANGE`` values. Colors are
+    mapped to a continuous linear gradient between the
+    two values. 
+    
+    See :ref:`kerneldensity` for further details on applying these to raster layers, 
+    and :ref:`RFC6` for working with vector layers. 
+    
+
+.. index::
+   pair: STYLE; DATARANGE
+
+DATARANGE [integer|double] [integer|double]
+    Defines two values, a low value and a high value, that Mapserver will map to
+    the color range defined by the `COLORRANGE` entry.
+    Values must be integers or doubles. Colors are
+    mapped to a continuous linear gradient between the
+    two values. 
+    
+    See :ref:`kerneldensity` for further details on applying these to raster layers, 
+    and :ref:`RFC6` for working with vector layers. 
+
+.. index::
    pair: STYLE; GAP
 
 GAP [double]
@@ -678,6 +704,28 @@ POLAROFFSET [double|attribute] [double|attribute]
       END #layer
 
     .. versionadded:: 6.2 (:ref:`rfc78`)
+
+.. index::
+   pair: STYLE; RANGEITEM 
+
+RANGEITEM [attribute]
+
+    Specifies the attribute that will be used to
+    map colors between the high and low ends of the
+    `COLORRANGE` entry.  Colors are mapped to a
+    continuous linear gradient between the two values.
+
+    Here is an example mapping the values 0.0-1.0 to RED-GREEN:
+
+    .. code-block:: mapfile
+
+      STYLE
+          RANGEITEM "myAttr"
+          COLORRANGE 255 0 0  0 255 0
+          DATARANGE 0.0 1.0
+      END
+
+    See the associated RFC document :ref:`RFC6`.
 
 .. index::
    pair: STYLE; SIZE


### PR DESCRIPTION
See https://github.com/mapserver/mapserver/issues/3917. Most of text taken from http://trac.osgeo.org/mapserver/attachment/ticket/1305/doc.patch