### PR TITLE
Add binding options to OFFSET

### DIFF
--- a/en/mapfile/style.txt
+++ b/en/mapfile/style.txt
@@ -515,9 +515,11 @@ MINWIDTH [double]
 .. index::
    pair: STYLE; OFFSET
 
-OFFSET [x][y]
+OFFSET [double|attribute] [double|attribute]
     Geometry offset values in layer `SIZEUNITS`. In the general
-    case, `SIZEUNITS` will be pixels.
+    case, `SIZEUNITS` will be pixels. The first parameter corresponds
+    to a shift on the horizontal - `x`, and the second parameter to
+    and a shift on the vertical - `y`. 
 
     When scaling of symbols is in effect (`SYMBOLSCALEDENOM` is
     specified for the :ref:`LAYER`), `OFFSET` gives offset values in


### PR DESCRIPTION
Currently missing from docs, but attribute bindings can be used - see https://github.com/mapserver/mapserver/blob/d5c22cd3113ba85f5b1f1c406fe4055f75d04ce3/mapfile.c#L2727