### PR TITLE
Note Added as per issue #254

### DIFF
--- a/en/mapcache/config.txt
+++ b/en/mapcache/config.txt
@@ -25,6 +25,10 @@ It is an XML file comprising a list of entries, as outlined here:
 .. _mapcache_config_source:
 
 
+.. note::
+
+    The MapCache configuration file is only read when the Apache web server starts and the MapCache module is loaded. If you modify this file you will have to restart Apache for the changes to take effect.
+
 Source
 ================================================================================
 
@@ -32,10 +36,6 @@ A source is a service mod-mapcache can query to obtain image data. This is
 typically a WMS server accessible by a URL. (There are currently only WMS, WMTS
 and mapfile as sources, though others may be added later if the need arises,
 see :ref:`mapcache_sources`).
-
-.. note::
-
-    The MapCache configuration file is only read when the Apache web server starts and the MapCache module is loaded. If you modify this file you will have to restart Apache for the changes to take effect.
     
 .. code-block:: xml
 

--- a/en/mapcache/config.txt
+++ b/en/mapcache/config.txt
@@ -33,6 +33,10 @@ typically a WMS server accessible by a URL. (There are currently only WMS, WMTS
 and mapfile as sources, though others may be added later if the need arises,
 see :ref:`mapcache_sources`).
 
+.. note::
+
+    The MapCache configuration file is only read when the Apache web server starts and the MapCache module is loaded. If you modify this file you will have to restart Apache for the changes to take effect.
+    
 .. code-block:: xml
 
    <source name="vmap0" type="wms">
@@ -102,10 +106,6 @@ Cache
 ================================================================================
 
 A cache is a location where received tiles will be stored.
-
-.. note::
-
-    The MapCache configuration file is only read when the Apache web server starts and the MapCache module is loaded. If you modify this file you will have to restart Apache for the changes to take effect.
 
 .. code-block:: xml
 

--- a/en/mapcache/config.txt
+++ b/en/mapcache/config.txt
@@ -22,12 +22,13 @@ It is an XML file comprising a list of entries, as outlined here:
    </mapcache>
 
 
-.. _mapcache_config_source:
-
-
 .. note::
 
     The MapCache configuration file is only read when the Apache web server starts and the MapCache module is loaded. If you modify this file you will have to restart Apache for the changes to take effect.
+    
+.. _mapcache_config_source:
+
+
 
 Source
 ================================================================================

--- a/en/mapcache/config.txt
+++ b/en/mapcache/config.txt
@@ -103,6 +103,10 @@ Cache
 
 A cache is a location where received tiles will be stored.
 
+.. note::
+
+    The MapCache configuration file is only read when the Apache web server starts and the MapCache module is loaded. If you modify this file you will have to restart Apache for the changes to take effect.
+
 .. code-block:: xml
 
    <cache name="disk" type="disk">


### PR DESCRIPTION
This issue #254 says to add a note "The MapCache configuration file is only read when the Apache web server starts and the MapCache module is loaded. If you modify this file you will have to restart Apache for the changes to take effect." so I added it!