### PR TITLE
Added  libgdal-dev in highly recommended libraries

### DIFF
--- a/en/installation/unix.txt
+++ b/en/installation/unix.txt
@@ -82,6 +82,7 @@ You can also get the latest MapServer source code from :ref:`git`.
 * `OGR`_: OGR provides access to a lot of vector formats.
 * `GDAL <http://www.gdal.org/>`__: GDAL provides access to a lot of
   raster formats.
+* `libgdal-dev(required) <https://pkgs.org/download/libgdal-dev/>`__: Geospatial Data Abstraction Library
 
 -----------------------------------------------------------------------------
  Optional External Libraries


### PR DESCRIPTION
According to issue #236 libgdal-dev is now required library to I added it in highly recommended libraries with 'required' text