### PR TITLE
Removing broken link :- http://tinyows.org/trac/wiki/LibxmlSchemaGmlBug

### DIFF
--- a/en/development/rfc/ms-rfc-70.txt
+++ b/en/development/rfc/ms-rfc-70.txt
@@ -187,7 +187,7 @@ TinyOWS trunk on OGC CITE unit test:
 
 4.5 External Dependencies
 -------------------------
- - LibXML2 >= 2.6.20 (and libxml2 trunk to avoid GML XSD Schema, see: http://tinyows.org/trac/wiki/LibxmlSchemaGmlBug)
+ - LibXML2 >= 2.6.20 (and libxml2 trunk to avoid GML XSD Schema)
  - PostgreSQL >= 8.1.0
  - PostGIS >= 1.5.0
  - FastCGI is optional (but recommended)


### PR DESCRIPTION
After going through a long documentation. i notice that this link  has no connection.
so please remove this link :- http://tinyows.org/trac/wiki/LibxmlSchemaGmlBug