### PR TITLE
Added alt attribute to IMG tag

### DIFF
--- a/_templates/indexsidebar.html
+++ b/_templates/indexsidebar.html
@@ -11,13 +11,13 @@
 <a href="https://twitter.com/mapserver_osgeo" title="Twitter">Twitter</a>
 </p>
 <a href="http://www.osgeo.org/">
-    <img src="{{ pathto("_static/OSGeo_project.png", 1) }}" border="0px; text-decoration:none" />
+    <img src="{{ pathto("_static/OSGeo_project.png" alt="OSGeo", 1) }}" border="0px; text-decoration:none" />
 </a>
 <p>MapServer is a project of the <a href="http://www.osgeo.org/">
 Open Source Geospatial Foundation</a>.</p>
 <p>
 <a href="http://2018.foss4g.org/">
-    <img src="{{ pathto("_static/foss4g2018.png", 1) }}" border="0px; text-decoration:none" />
+    <img src="{{ pathto("_static/foss4g2018.png" alt="FOSS4G", 1) }}" border="0px; text-decoration:none" />
 </a>
 </p>
 <p>


### PR DESCRIPTION
In this 2 images don't have an alt text and usually "alt tags help visually impaired people and search engines to figure out what is shown in an image. so It is required to have an alt text for every image".
Images that does not have are :- _static/OSGeo_project.png,_static/foss4g2018.png