### PR TITLE
defresolution type correction

### DIFF
--- a/en/mapfile/map.txt
+++ b/en/mapfile/map.txt
@@ -424,7 +424,7 @@ NAME [name]
     
 .. _resolution-parameter:
 
-RESOLUTION [int] Sets the pixels per inch for output, only affects
+RESOLUTION [double] Sets the pixels per inch for output, only affects
     scale computations.  Default is 72.
 
 .. index::

--- a/en/mapfile/map.txt
+++ b/en/mapfile/map.txt
@@ -271,7 +271,7 @@ DEBUG [off|on|0|1|2|3|4|5]
 .. index::
     pair: MAP; DEFRESOLUTIONx
     
-DEFRESOLUTION [int] 
+DEFRESOLUTION [double] 
     Sets the reference resolution (pixels per inch) used for
     symbology.  Default is 72.
      


### PR DESCRIPTION
The type of the attribute defresolution was not coherent with the code. In the cpp code is as a double and in the docs was shown as an int.