### PR TITLE
Set code language to HTML on Tile Mode page

### DIFF
--- a/en/output/tile_mode.txt
+++ b/en/output/tile_mode.txt
@@ -120,7 +120,7 @@ The `Google Maps API`_ includes support for using alternative tile sets
 as overlays, or as alternate base maps. Here is an example of an 
 `GTileLayerOverlay`_
 
-.. code-block:: guess
+.. code-block:: html
     :linenos:
     
     <!DOCTYPE html 
@@ -167,7 +167,7 @@ and zoom level on the fly to retrieve tiles from your server.
 
 You can also use a MapServer tile layer as an alternate base map:
 
-.. code-block:: guess
+.. code-block:: html
     :linenos:
 
     <!DOCTYPE html 
@@ -220,7 +220,7 @@ Using Virtual Earth
 The `Virtual Earth API`_ also includes support for using alternative tile sets 
 as overlays, or as alternate base maps. Here is an example:
 
-.. code-block:: guess
+.. code-block:: html
     :linenos:
     
     <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">


### PR DESCRIPTION
The following errors are currently in the Travis builds:
```
home/travis/build/mapserver/docs/en/output/tile_mode.txt:123: WARNING: Could not lex literal_block as "guess". Highlighting skipped.
/home/travis/build/mapserver/docs/en/output/tile_mode.txt:170: WARNING: Could not lex literal_block as "guess". Highlighting skipped.
/home/travis/build/mapserver/docs/en/output/tile_mode.txt:223: WARNING: Could not lex literal_block as "guess". Highlighting skipped.
```