### PR TITLE
Add clarifications with regards to brackets and EXPRESSIONS

### DIFF
--- a/en/mapfile/expressions.txt
+++ b/en/mapfile/expressions.txt
@@ -411,7 +411,8 @@ The type of attributes and literals is determined as followed :
 Logical expressions
 ...............................................................................
 
-Logical expressions take logical values as their input and return logical values. A logical expression is either 'true'
+Logical expressions take logical values as their input and return logical
+values. A logical expression is either 'true' or 'false'.
 or 'false'. The full expression needs to be surrounded by brackets, but individual logical expressions only
 require brackets to establish precedence or for clarity. 
 

--- a/en/mapfile/expressions.txt
+++ b/en/mapfile/expressions.txt
@@ -411,21 +411,21 @@ The type of attributes and literals is determined as followed :
 Logical expressions
 ...............................................................................
 
-Syntactically, a logical expression is everything encapsulated in
-round brackets.  Logical expressions take logical values as their
-input and return logical values. A logical expression is either 'true'
-or 'false'.
+Logical expressions take logical values as their input and return logical values. A logical expression is either 'true'
+or 'false'. The full expression needs to be surrounded by brackets, but individual logical expressions only
+require brackets to establish precedence or for clarity. 
 
 .. index::
    pair: Expressions; and
 
-* ( ( Expression1 ) AND ( Expression2 ) )
+* ( Expression1 AND Expression2 )
+
+  ( ( Expression1 ) AND ( Expression2 ) )
 
   ( ( Expression1 ) && ( Expression2 ) )
 
   returns true when both of the logical expressions (Expression1 and
-  Expression2) are true.
-
+  Expression2) are true. 
 
 .. index::
    pair: Expressions; or

--- a/en/mapfile/expressions.txt
+++ b/en/mapfile/expressions.txt
@@ -415,7 +415,6 @@ Logical expressions take logical values as their input and return logical
 values. A logical expression is either 'true' or 'false'.
 The full expression needs to be surrounded by brackets, but individual
 logical expressions only require brackets to establish precedence or for clarity.
-require brackets to establish precedence or for clarity. 
 
 .. index::
    pair: Expressions; and

--- a/en/mapfile/expressions.txt
+++ b/en/mapfile/expressions.txt
@@ -413,7 +413,8 @@ Logical expressions
 
 Logical expressions take logical values as their input and return logical
 values. A logical expression is either 'true' or 'false'.
-or 'false'. The full expression needs to be surrounded by brackets, but individual logical expressions only
+The full expression needs to be surrounded by brackets, but individual
+logical expressions only require brackets to establish precedence or for clarity.
 require brackets to establish precedence or for clarity. 
 
 .. index::


### PR DESCRIPTION
Previously the docs implied all individual parts of an expression required brackets. 
See https://github.com/mapserver/mapserver/pull/5897 for tests and discussion at https://github.com/geographika/mappyfile/issues/85