### PR TITLE
Add example of spaces in expressions

### DIFF
--- a/en/mapfile/expressions.txt
+++ b/en/mapfile/expressions.txt
@@ -330,7 +330,7 @@ List expressions (see :ref:`rfc95`) are a performant way to compare a
 string attribute to a list of multiple possible values. Their behavior
 duplicates the existing regex or mapserver expressions, however they are
 significantly more performant. To activate them enclose a comma separated
-list of values between {}, **without** adding quotes or extra spaces. 
+list of values between {}, **without** adding quotes or extra spaces.
 
 
 ::

--- a/en/mapfile/expressions.txt
+++ b/en/mapfile/expressions.txt
@@ -330,7 +330,7 @@ List expressions (see :ref:`rfc95`) are a performant way to compare a
 string attribute to a list of multiple possible values. Their behavior
 duplicates the existing regex or mapserver expressions, however they are
 significantly more performant. To activate them enclose a comma separated
-list of values between {}, **without** adding quotes or extra spaces.
+list of values between {}, **without** adding quotes or extra spaces. 
 
 
 ::
@@ -346,7 +346,8 @@ list of values between {}, **without** adding quotes or extra spaces.
           ...
         END
         CLASS
-          EXPRESSION {primary,secondary}
+          # spaces in attribute names are supported
+          EXPRESSION {primary road,secondary road}
           ...
         END
     END


### PR DESCRIPTION
As reported at https://github.com/geographika/mappyfile/issues/89 - add an example showing spaces in expressions and note that they are allowed. 