### PR TITLE
Corrects DEMIME documentation

### DIFF
--- a/en/development/tests/autotest.txt
+++ b/en/development/tests/autotest.txt
@@ -280,7 +280,7 @@ redirected to a file.
     # RUN_PARMS: wcs_cap.xml [MAPSERV] QUERY_STRING='map=[MAPFILE]&SERVICE=WCS&VERSION=1.0.0&REQUEST=GetCapabilities' > [RESULT]
 
 For web services that generate images that would normally be prefixed with the
-Content-type header, use [RESULT_NOMIME] to instruct the test harnass to
+Content-type header, use [RESULT_DEMIME] to instruct the test harnass to
 script off any http headers before doing the comparison.  This is particularly
 valuable for image results so the files can be compared using special image
 comparisons.


### PR DESCRIPTION
In the documentation regarding how to demime results of tests it is mentioned as RESULT_NOMIME instead of RESULT_DEMIME