### PR TITLE
Upgrade MapCache proxying document to latest configuration syntax

### DIFF
--- a/en/mapcache/proxying.txt
+++ b/en/mapcache/proxying.txt
@@ -57,22 +57,27 @@ and are added with the <param> keyword:
 .. code-block:: xml
 
    <forwarding_rule name="first rule">
-     <param name="SERVICE" type="values">WFS,WCS</param>
-     <!-- ... !>
+     <param name="SERVICE" type="values">
+       <value>WFS</value>
+       <value>WCS</value>
+     </param>
+     <!-- ... -->
    <forwarding_rule>
 
-The "type" attribute is the same as what is allowed for :ref:`dimensions
-<mapcache_dimensions>`, i.e. allowed values are "values", "regex", and
-"intervals". In the previous example, the rule would match any incoming
-request having ...&SERVICE=WFS&... or ...&SERVICE=WCS&... in its request
-parameters.
+The "type" attribute is the same as what is allowed for :ref:`first level
+dimensions <mapcache_dimensions>`, i.e. allowed values are "values" and
+"regex". In the previous example, the rule would match any incoming request
+having ...&SERVICE=WFS&... or ...&SERVICE=WCS&... in its request parameters.
 
 .. code-block:: xml
 
    <forwarding_rule name="first rule">
-     <param name="SERVICE" type="values">WFS,WCS</param>
-     <param name="LAYERS" type="values">somelayername</param>
-     <!-- ... !>
+     <param name="SERVICE" type="values">
+       <value>WFS</value>
+       <value>WCS</value>
+     </param>
+     <param name="LAYERS" type="values"><value>somelayername</value></param>
+     <!-- ... -->
    <forwarding_rule>
 
 Multiple rules can be used if the filtering has to be done on multiple
@@ -96,7 +101,7 @@ request to another server.
 .. code-block:: xml
 
    <forwarding_rule name="first rule">
-     <!-- ... !>
+     <!-- ... -->
      <http>
         <url>http://wmsserver/ogc.cgi?</url>
      </http>


### PR DESCRIPTION
MapCache issue [#173](https://github.com/mapserver/mapcache/issues/173) raises an inconsistency between documentation and actual implementation. This PR aims at fixing outdated documentation.