### PR TITLE
Fix MapCache time dimension examples and explanation

### DIFF
--- a/en/mapcache/dimensions.txt
+++ b/en/mapcache/dimensions.txt
@@ -495,7 +495,7 @@ Configuring a Time Dimension using a default SQLite back-end
                       AND ts &lt;= datetime(:end_timestamp,"unixepoch")
                  ORDER BY ts DESC
               </validate_query>
-              <list_query>SELECT ts FROM time</list_query>
+              <list_query>SELECT strftime("%Y-%m-%dT%H:%M:%SZ", ts) FROM time</list_query>
           </dimension>
 
    * - Up to MapCache 1.6.1
@@ -518,7 +518,7 @@ Configuring a Time dimension using an explicit back-end
     -->
     <dimension type="sqlite" name="time" default="d1" time="true">
       <dbfile>/data/times.sqlite</dbfile>
-      <list_query>SELECT ts FROM timedim</list_query>
+      <list_query>SELECT strftime("%Y-%m-%dT%H:%M:%SZ", ts) FROM timedim</list_query>
       <validate_query>
            SELECT strftime("%Y-%m-%dT%H:%M:%SZ",ts) FROM timedim
             WHERE ts &gt;= datetime(:start_timestamp,"unixepoch")
@@ -543,7 +543,7 @@ Configuring a Time dimension using an explicit back-end
       <connection>
         host=localhost user=mapcache password=mapcache dbname=times port=5433
       </connection>
-      <list_query>SELECT ts FROM timedim</list_query>
+      <list_query>SELECT to_char(ts, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') FROM timedim</list_query>
       <validate_query>
            SELECT to_char(ts,'YYYY-MM-DD"T"HH24:MI:SS"Z"') FROM timedim
             WHERE ts &gt;= to_timestamp(:start_timestamp)

--- a/en/mapcache/dimensions.txt
+++ b/en/mapcache/dimensions.txt
@@ -440,8 +440,10 @@ Still, MapCache keeps an (almost) backward compatible configuration of Time
 dimension with an implicit SQLite back-end. Example in the following section
 highlights differences.
 
-Time values in the dynamic back-end are expressed in Unix time, i.e. the number
-of seconds that have elapsed since January 1, 1970 (midnight UTC).
+Time values used to query the dynamic back-end are expressed in Unix time,
+i.e. the number of seconds that have elapsed since January 1, 1970
+(midnight UTC). Returned times should be MapServer compatible strings
+(see the :ref:`WMS Time documentation <wms_time>` for details).
 
 Querying the back-end with an interval may result in returning multiple
 timestamp values, each of which referencing distinct tiles. Assembling these


### PR DESCRIPTION
This is an attempt at fixing https://github.com/mapserver/mapcache/issues/228

From what I can tell, the `list_query` is used to list available times for (primarily?) the `demo` service. If the `list_query` returns strings or integers that aren't compatible with MapCache/MapServer then the `demo` service will just use those TIMEs as-is. This results in a `demo` that has invalid WMTS (or other service) requests.

I ran in to this because the way I read the documentation made it seem like I had to store and/or return epoch seconds from the database. I then switched to whatever the default is for python's sqlite3 module when storing datetime objects. That was invalid because it didn't include the `Z` at the end (my datetimes didn't have timezones).

Anyway this PR is my attempt at trying to clear this up. I'm not sure if the elastic search example needs to be changed or how it would be.

Side note: I'm not sure MapCache supports all the same time formats that MapServer says it does: https://github.com/mapserver/mapcache/blob/3eb53ca81a7596bf4fc1706e83284eaf4d31940a/lib/dimension_time.c#L63 versus https://mapserver.org/ogc/wms_time.html#time-patterns.