### PR TITLE
add doc for [attribute] in ALIGN, OFFSET, and POSITION

### DIFF
--- a/en/mapfile/label.txt
+++ b/en/mapfile/label.txt
@@ -20,7 +20,8 @@ ALIGN [left|center|right|attribute]
     [attribute] was added in version 7.6. If an attribute is used,
     it is expected to be:
 
-    *  of type *string* and should be one of the following: *left*, *center*, *right*.
+    * of type *string* and should be one of the following: *left*, *center*, *right*.
+
     * of type *integer* and should be [1,2,3] which means:
 
       * 1 = "left"

--- a/en/mapfile/label.txt
+++ b/en/mapfile/label.txt
@@ -10,11 +10,29 @@
 .. index::
    pair: LABEL; ALIGN
 
-ALIGN [left|center|right]
+ALIGN [left|center|right|attribute]
     Specifies text alignment for multiline labels (see WRAP_) Note
     that the alignment algorithm is far from precise, so don't expect
     fabulous results (especially for *right* alignment) if you're not
     using a fixed width font.
+
+
+    [attribute] was added in version 7.6. If an attribute is used,
+    it is expected to be:
+
+    *  of type *string* and should be one of the following: *left*, *center*, *right*.
+    * of type *integer* and should be [1,2,3] which means:
+
+      * 1 = "left"
+      * 2 = "center"
+      * 3 = "right"
+
+
+    if the [attribute] is of type *integer* as described above, the label
+    generation will be much faster as no string comparison are made.
+
+
+
 
     .. versionadded:: 5.4
 
@@ -28,7 +46,7 @@ ANGLE [double|auto|auto2|follow|attribute]
       layers only.
     - AUTO2 same as AUTO, except no logic is applied to try to keep
       the text from being rendered in reading orientation (i.e. the
-      text may be rendered upside down). Useful when adding text 
+      text may be rendered upside down). Useful when adding text
       arrows indicating the line direction.
     - FOLLOW was introduced in version 4.10 and tells MapServer to
       compute a curved label for appropriate linear features (see
@@ -43,14 +61,14 @@ ANGLE [double|auto|auto2|follow|attribute]
 
         LABEL
           COLOR  150 150 150
-          OUTLINECOLOR 255 255 255     
+          OUTLINECOLOR 255 255 255
           FONT "sans"
           TYPE truetype
           SIZE 6
           ANGLE [MYANGLE]
-          POSITION AUTO      
+          POSITION AUTO
           PARTIALS FALSE
-        END 
+        END
 
       The associated RFC document for this feature is :ref:`RFC19`.
 
@@ -72,7 +90,7 @@ BACKGROUNDCOLOR [r] [g] [b] | [hexadecimal string]
        `GEOMTRANSFORM labelpoly` and `COLOR`.
 
 BACKGROUNDSHADOWCOLOR [r] [g] [b] | [hexadecimal string]
-    Color to draw a background rectangle (i.e. billboard) shadow. Off by 
+    Color to draw a background rectangle (i.e. billboard) shadow. Off by
     default.
 
     .. note::
@@ -90,8 +108,8 @@ BACKGROUNDSHADOWSIZE [x][y]
    pair: LABEL; BUFFER
 
 BUFFER [integer]
-    Padding, in pixels, around labels. Useful for maintaining spacing around 
-    text to enhance readability. Available only for cached labels. 
+    Padding, in pixels, around labels. Useful for maintaining spacing around
+    text to enhance readability. Available only for cached labels.
     Default is 0.
 
 .. index::
@@ -99,14 +117,14 @@ BUFFER [integer]
 
 COLOR [r] [g] [b] | [hexadecimal string] | [attribute]
     - Color to draw text with.
-    
+
     - `r`, `g` and `b` shall be integers [0..255].  To specify green,
       the following is used:
 
         .. code-block:: mapfile
 
-           COLOR 0 255 0    
-    
+           COLOR 0 255 0
+
     - `hexadecimal string` can be
 
       - RGB value: "#rrggbb".  To specify magenta, the following is
@@ -121,8 +139,8 @@ COLOR [r] [g] [b] | [hexadecimal string] | [attribute]
 
         .. code-block:: mapfile
 
-           COLOR "#FF00FFCC"  
-           
+           COLOR "#FF00FFCC"
+
     - [*Attribute*] was introduced in version 5.0, to specify the item
       name in the attribute table to use for color values.  The hard
       brackets [] are required.  For example, if your shapefile's DBF
@@ -133,13 +151,13 @@ COLOR [r] [g] [b] | [hexadecimal string] | [attribute]
 
         LABEL
           COLOR  [MYCOLOR]
-          OUTLINECOLOR 255 255 255     
+          OUTLINECOLOR 255 255 255
           FONT "sans"
           TYPE truetype
           SIZE 6
-          POSITION AUTO      
+          POSITION AUTO
           PARTIALS FALSE
-        END 
+        END
 
       The associated RFC document for this feature is :ref:`RFC19`.
 
@@ -177,7 +195,7 @@ FONT [name|attribute]
     - [*Attribute*] was introduced in version 5.6 to specfify the font
       alias.
     - May contain a comma-separated list of up to MS_MAX_LABEL_FONTS
-      (usually 5) font aliases used as fallback fonts in renderers 
+      (usually 5) font aliases used as fallback fonts in renderers
       supporting it, if a glyph is not available in a font. If specified
       directly, be sure to enclose the list with quotes. See :ref:`RFC80`.
     - Since version 7, MapServer supports language specific fonts.
@@ -207,7 +225,7 @@ MAXLENGTH [integer]
 
         "", **maxlength = 0** ,  **maxlength > 0**
         **wrap = ‘char’** ,always wrap at the WRAP_ character ,newline at the first WRAP_ character after MAXLENGTH_ characters
-        **no wrap** ,no processing,skip label if it contains more than MAXLENGTH_ characters 
+        **no wrap** ,no processing,skip label if it contains more than MAXLENGTH_ characters
 
     The associated RFC document for this feature is :ref:`RFC40`.
 
@@ -233,7 +251,7 @@ MAXOVERLAPANGLE [double]
     (40% of 180 degrees = 72degree).
 
     The associated RFC document for this feature is :ref:`RFC60`.
-                   
+
 .. index::
    pair: LABEL; MAXSCALEDENOM
 
@@ -245,7 +263,7 @@ MAXSCALEDENOM [double]
     .. versionadded:: 5.4
 
     .. seealso::
-        
+
         :term:`Map Scale`
 
 .. index::
@@ -253,9 +271,9 @@ MAXSCALEDENOM [double]
 
 MAXSIZE [double]
     Maximum font size to use when scaling text (pixels). Default is 256.
-    Starting from version 5.4, the value can also be a fractional value 
+    Starting from version 5.4, the value can also be a fractional value
     (and not only integer).
-    See :ref:`LAYER` :ref:`SYMBOLSCALEDENOM <symbolscaledenom>`.   
+    See :ref:`LAYER` :ref:`SYMBOLSCALEDENOM <symbolscaledenom>`.
 
 .. index::
    pair: LABEL; MINDISTANCE
@@ -287,7 +305,7 @@ MINSCALEDENOM [double]
     .. versionadded:: 5.4
 
     .. seealso::
-        
+
         :term:`Map Scale`
 
 .. index::
@@ -295,18 +313,23 @@ MINSCALEDENOM [double]
 
 MINSIZE [double]
     Minimum font size to use when scaling text (pixels). Default is 4.
-    Starting from version 5.4, the value can also be a fractional value 
-    (and not only integer).     
-    See :ref:`LAYER` :ref:`SYMBOLSCALEDENOM <symbolscaledenom>`.   
+    Starting from version 5.4, the value can also be a fractional value
+    (and not only integer).
+    See :ref:`LAYER` :ref:`SYMBOLSCALEDENOM <symbolscaledenom>`.
 
 .. index::
    pair: LABEL; OFFSET
 
-OFFSET [x][y]
-    Offset values for labels, relative to the lower left hand corner of the 
-    label and the label point. Given in pixels. In the case of rotated text 
-    specify the values as if all labels are horizontal and any rotation will 
+OFFSET [x|attribute_x][y|attribute_y]
+    Offset values for labels, relative to the lower left hand corner of the
+    label and the label point. Given in pixels. In the case of rotated text
+    specify the values as if all labels are horizontal and any rotation will
     be compensated for.
+
+
+    [attribute_x] and [attribute_y] were added in version 7.6. If an attribute
+    is used, it must be of type *integer*.
+
 
     When used with FOLLOW angle, two additional options are available to
     render the label parallel to the original feature:
@@ -315,6 +338,7 @@ OFFSET [x][y]
       feature, depending on the sign of {x}.
     - OFFSET x 99 : will render the label above or below the feature,
       depending on the sign of {x}.
+
 
     See :ref:`LAYER` :ref:`SYMBOLSCALEDENOM <symbolscaledenom>`.
 
@@ -325,14 +349,14 @@ OFFSET [x][y]
 
 OUTLINECOLOR [r] [g] [b] | [hexadecimal string] | [attribute]
     - Color to draw a one pixel outline around the characters in the text.
-    
+
     - `r`, `g` and `b` shall be integers [0..255].  To specify green,
       the following is used:
 
         .. code-block:: mapfile
 
-           OUTLINECOLOR 0 255 0    
-    
+           OUTLINECOLOR 0 255 0
+
     - `hexadecimal string` can be
 
       - RGB value: "#rrggbb".  To specify magenta, the following is
@@ -347,8 +371,8 @@ OUTLINECOLOR [r] [g] [b] | [hexadecimal string] | [attribute]
 
         .. code-block:: mapfile
 
-           OUTLINECOLOR "#FF00FFCC"  
-           
+           OUTLINECOLOR "#FF00FFCC"
+
     - [*attribute*] was introduced in version 5.0, to specify the item
       name in the attribute table to use for color values.  The hard
       brackets [] are required.  For example, if your shapefile's DBF
@@ -359,13 +383,13 @@ OUTLINECOLOR [r] [g] [b] | [hexadecimal string] | [attribute]
 
         LABEL
           COLOR  150 150 150
-          OUTLINECOLOR [MYOUTCOLOR]     
+          OUTLINECOLOR [MYOUTCOLOR]
           FONT "sans"
           TYPE truetype
           SIZE 6
-          POSITION AUTO      
+          POSITION AUTO
           PARTIALS FALSE
-        END 
+        END
 
       The associated RFC document for this feature is :ref:`RFC19`.
 
@@ -394,7 +418,7 @@ PARTIALS [true|false]
 .. index::
    pair: LABEL; POSITION
 
-POSITION [ul|uc|ur|cl|cc|cr|ll|lc|lr|auto]
+POSITION [ul|uc|ur|cl|cc|cr|ll|lc|lr|auto|attribute]
     Position of the label relative to the labeling point (layers
     only). First letter is "Y" position, second letter is "X"
     position. "Auto" tells MapServer to calculate a label position
@@ -407,6 +431,9 @@ POSITION [ul|uc|ur|cl|cc|cr|ll|lc|lr|auto]
     then the label is not drawn (Unless the label's FORCE_ a parameter
     is set to "true"). "Auto" placement is only available with cached
     labels.
+
+    When used with attribute, it must be of type *string* and use one
+    of the following: *ul|uc|ur|cl|cc|cr|ll|lc|lr|auto*.
 
 .. index::
    pair: LABEL; PRIORITY
@@ -432,7 +459,7 @@ PRIORITY [integer]|[item_name]|[attribute]
 .. index::
    pair: LABEL; REPEATDISTANCE
 
-REPEATDISTANCE [integer] 
+REPEATDISTANCE [integer]
     The label will be repeated on every line of a multiline shape and
     will be repeated multiple times along a given line at an interval
     of REPEATDISTANCE pixels.
@@ -449,14 +476,14 @@ SHADOWCOLOR [r] [g] [b] | [hexadecimal string]
     in this color before the main label is drawn, resulting in a
     shadow effect on the the label characters. The offset of the
     renderered shadow is set with SHADOWSIZE.
-    
+
     - `r`, `g` and `b` shall be integers [0..255].  To specify green,
       the following is used:
 
         .. code-block:: mapfile
 
-           SHADOWCOLOR 0 255 0     
-    
+           SHADOWCOLOR 0 255 0
+
     - `hexadecimal string` can be
 
       - RGB value: "#rrggbb".  To specify magenta, the following is
@@ -471,7 +498,7 @@ SHADOWCOLOR [r] [g] [b] | [hexadecimal string]
 
         .. code-block:: mapfile
 
-           SHADOWCOLOR "#FF00FFCC"      
+           SHADOWCOLOR "#FF00FFCC"
 
 .. index::
    pair: LABEL; SHADOWSIZE
@@ -513,19 +540,19 @@ SIZE [integer]|[tiny|small|medium|large|giant]|[attribute]
 
         LABEL
           COLOR  150 150 150
-          OUTLINECOLOR 255 255 255     
+          OUTLINECOLOR 255 255 255
           FONT "sans"
           TYPE truetype
           SIZE [MYSIZE]
-          POSITION AUTO      
+          POSITION AUTO
           PARTIALS FALSE
-        END 
+        END
 
       The associated RFC document for this feature is :ref:`RFC19`.
-      
+
     .. note::
          The SIZE value can only be an integer (not a fractional
-         value), because the renderer Freetype only accepts integers.     
+         value), because the renderer Freetype only accepts integers.
 
 .. index::
    pair: LABEL; STYLE
@@ -543,8 +570,8 @@ SIZE [integer]|[tiny|small|medium|large|giant]|[attribute]
       apply to ANGLE FOLLOW labels.
 
       - labelpnt draws a marker on the geographic position the label is
-        attached to. This corresponds to the center of the label text 
-        only if the label is in position CC. 
+        attached to. This corresponds to the center of the label text
+        only if the label is in position CC.
 
       - labelpoly generates the bounding rectangle for the text, with
         1 pixel of padding added in all directions.
@@ -556,7 +583,7 @@ SIZE [integer]|[tiny|small|medium|large|giant]|[attribute]
         (i.e. billboard) with a "shadow" in gray:
 
         .. code-block:: mapfile
- 
+
           STYLE
             GEOMTRANSFORM 'labelpoly'
             COLOR 153 153 153
@@ -593,7 +620,7 @@ TYPE [bitmap|truetype]
     then TrueType fonts. However, TrueType fonts are scalable and
     available in a variety of faces. Be sure to set the FONT parameter
     if you select TrueType.
-    
+
     .. note::
          Bitmap fonts are only supported with the AGG and GD
          renderers.

--- a/en/mapfile/label.txt
+++ b/en/mapfile/label.txt
@@ -31,7 +31,6 @@ ALIGN [left|center|right|attribute]
     generation will be much faster as no string comparison are made.
 
 
-
     .. versionadded:: 5.4
 
 .. index::

--- a/en/mapfile/label.txt
+++ b/en/mapfile/label.txt
@@ -28,7 +28,8 @@ ALIGN [left|center|right|attribute]
       * 3 = "right"
 
     if the [attribute] is of type *integer* as described above, the label
-    generation will be much faster as no string comparison are made.
+    generation will be much faster, since string comparison is avoided.
+
 
 
     .. versionadded:: 5.4

--- a/en/mapfile/label.txt
+++ b/en/mapfile/label.txt
@@ -16,7 +16,6 @@ ALIGN [left|center|right|attribute]
     fabulous results (especially for *right* alignment) if you're not
     using a fixed width font.
 
-
     [attribute] was added in version 7.6. If an attribute is used,
     it is expected to be:
 

--- a/en/mapfile/label.txt
+++ b/en/mapfile/label.txt
@@ -28,7 +28,6 @@ ALIGN [left|center|right|attribute]
       * 2 = "center"
       * 3 = "right"
 
-
     if the [attribute] is of type *integer* as described above, the label
     generation will be much faster as no string comparison are made.
 

--- a/en/mapfile/label.txt
+++ b/en/mapfile/label.txt
@@ -330,7 +330,6 @@ OFFSET [x|attribute_x][y|attribute_y]
     [attribute_x] and [attribute_y] were added in version 7.6. If an attribute
     is used, it must be of type *integer*.
 
-
     When used with FOLLOW angle, two additional options are available to
     render the label parallel to the original feature:
 

--- a/en/mapfile/label.txt
+++ b/en/mapfile/label.txt
@@ -326,7 +326,6 @@ OFFSET [x|attribute_x][y|attribute_y]
     specify the values as if all labels are horizontal and any rotation will
     be compensated for.
 
-
     [attribute_x] and [attribute_y] were added in version 7.6. If an attribute
     is used, it must be of type *integer*.
 

--- a/en/mapfile/label.txt
+++ b/en/mapfile/label.txt
@@ -34,7 +34,6 @@ ALIGN [left|center|right|attribute]
 
 
 
-
     .. versionadded:: 5.4
 
 .. index::


### PR DESCRIPTION
This is documentation relative to the [following PR](https://github.com/mapserver/mapserver/pull/6052) in mapserver repository.

I noticed that the documentation for `[attribute]` in POSITION was missing, so I added it too.