### PR TITLE
Add name options to index directives

### DIFF
--- a/en/mapfile/class.txt
+++ b/en/mapfile/class.txt
@@ -7,8 +7,9 @@
  CLASS
 *****************************************************************************
 
-.. index::
+.. index:: 
    pair: CLASS; BACKGROUNDCOLOR
+   :name: mapfile-class-background   
     
 BACKGROUNDCOLOR [r] [g] [b] | [hexadecimal string]
 
@@ -16,6 +17,7 @@ BACKGROUNDCOLOR [r] [g] [b] | [hexadecimal string]
  
 .. index::
    pair: CLASS; COLOR
+   :name: mapfile-class-color   
     
 COLOR [r] [g] [b] | [hexadecimal string]
 


### PR DESCRIPTION
This pull request is to get opinions on adding a `:name:` to all the Mapfile index directives. 

In summary all index directives would be updated from:

```
.. index:: 
    pair: CLASS; BACKGROUNDCOLOR
```

to:

```
.. index:: 
    pair: CLASS; BACKGROUNDCOLOR
    :name: mapfile-class-background   
```

Links in the index will then change from https://mapserver.org/mapfile/class.html#index-1 which can change to a fixed URL - https://mapserver.org/mapfile/class.html#mapfile-class-background

This would form part of the updates to the MapScript API documentation updates - see [here](https://github.com/mapserver/mapserver/pull/5870). Named index options allow an HTML link to be added from the MapScript docs to the relevant Mapfile keyword. 

I've asked a [question on StackOverflow](https://stackoverflow.com/questions/61666809/parse-and-write-rst-using-docutils) to see if it is possible to automate it with docutils, but otherwise it will be a manual/parse/regex approach. 

I added the `:name:` option to Sphinx as part of the version 3.0 release with [this pull request](https://github.com/sphinx-doc/sphinx/pull/7087), mainly for this use case. The docs for the option [are here](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-option-index-name). 

I've created the pull request against master, but can make it against 7.6 if appropriate, and update the remaining Mapfile index directives. 
