### PR TITLE
Add HTML Entity Character option

### DIFF
--- a/en/mapfile/symbol.txt
+++ b/en/mapfile/symbol.txt
@@ -80,6 +80,18 @@ CHARACTER [char]
     Character used to reference a particular TrueType font character. 
     You'll need to figure out the mapping from the keyboard character 
     to font character.
+    
+    HTML entity numbers can also be used, for example:
+    
+    .. code-block:: mapfile
+
+        SYMBOL
+          NAME "right-arrow"
+          COLOR 255 255 255
+          TYPE TRUETYPE
+          FONT "dejavu"
+          CHARACTER "&#10140;"
+        END
 
 .. index::
    pair: SYMBOL; FILLED

--- a/en/mapfile/symbol.txt
+++ b/en/mapfile/symbol.txt
@@ -76,7 +76,7 @@ ANTIALIAS [true|false]
    pair: SYMBOL; CHARACTER
    :name: mapfile-symbol-character
     
-CHARACTER [char]
+CHARACTER [char|entity number]
     Character used to reference a particular TrueType font character. 
     You'll need to figure out the mapping from the keyboard character 
     to font character.


### PR DESCRIPTION
Characters can also be set using HTML entity numbers e.g. the codes listed at https://entitycode.com/

See [this msautotest](https://github.com/mapserver/mapserver/blob/85e294e8c8ce3c9c455fea0137d4af1ee2feced0/msautotest/renderers/multilabel-leader.map) for example. 