### PR TITLE
Add FORCE GROUP keyword

### DIFF
--- a/en/mapfile/label.txt
+++ b/en/mapfile/label.txt
@@ -211,11 +211,16 @@ FONT [name|attribute]
 
 .. _FORCE:
 
-FORCE [true|false]
+FORCE [true|false|group]
     Forces labels for a particular class on, regardless of collisions.
     Available only for cached labels.  Default is false.  If `FORCE`
     is true and `PARTIALS` is false, `FORCE` takes precedence, and
     partial labels are drawn.
+    
+    The GROUP parameter, added in verion 6.2, determines if the label 
+    is allowed to intersect other labels from the same feature or not, and 
+    multiple STYLE blocks can be used to render graphic symbols instead of 
+    or alongside the text. 
 
 .. index::
    pair: LABEL; MAXLENGTH


### PR DESCRIPTION
Add the GROUP keyword added in 6.2
See thread at https://lists.osgeo.org/pipermail/mapserver-dev/2020-July/016241.html and 6.2 release notes at https://mapserver.org/development/announce/6-2.html#complex-multi-label-symbol-symbology