### PR TITLE
Update how gml_types auto is handled

### DIFF
--- a/en/ogc/wfs_server.txt
+++ b/en/ogc/wfs_server.txt
@@ -11,7 +11,7 @@
 :Contact: jmckenna at gatewaygeomatics.com
 :Author: Even Rouault
 :Contact: even.rouault at mines-paris.org
-:Last Updated: 2019-07-02
+:Last Updated: 2020-09-14
 
 .. contents::
     :depth: 2
@@ -1133,12 +1133,18 @@ Layer Object
    triple: WFS; METADATA; gml_types
 
 **gml_types**
-  (Optional) If this field is "auto" then some input feature drivers
-  (ie.  OGR, POSTGIS, ORACLESPATIAL and native shapefiles) will
+  (Optional) If this field is set to "auto" then the OGR, POSTGIS, ORACLESPATIAL,
+  MSSQL, and native Shapefiles input feature drivers will
   automatically populate the type, width and precision metadata for
   the layer based on the source file. This is mainly used by
   OGR based output formats, as well as the WFS GML2/GML3 output to format
-  dates.
+  dates. 
+  
+  In addition the MSSQL driver also sets nillable="true" in the output GML
+  for any database fields that accept NULLs.
+
+  This option can be overridden by setting 
+  gml_[item name]_type for individual fields.
 
   ::
 


### PR DESCRIPTION
Updates related to https://github.com/mapserver/mapserver/pull/6137
Add that individual field metadata can be overwritten if required, and the MSSQL driver supports "gml_types" "auto". 
As this code change could change/break existing how GML is currently returned I've made the pull request against master, as I'm not sure if this should be backported. 